### PR TITLE
tutorial/address-book: edit Active Link Styling in sidebar

### DIFF
--- a/tutorials/address-book/app/data.ts
+++ b/tutorials/address-book/app/data.ts
@@ -311,6 +311,6 @@ export async function deleteContact(id: string) {
 ].forEach((contact) => {
   fakeContacts.create({
     ...contact,
-    id: `${contact.first.toLowerCase()}-${contact.last.toLocaleLowerCase()}`,
+    id: `${contact.first.toLowerCase().split(' ').join('_')}-${contact.last.toLocaleLowerCase()}`,
   });
 });


### PR DESCRIPTION
After returning from the contacts/:contactId/edit  page to contacts/:contactId page active link styling will disappear for the contact that has first name and middle name like "Kent C.  + Doods" because the URL will be /contacts/kent c.-doods or /contacts/%20c.-doods.

So, in the /app/data.ts in the last line where ids are added for every contact created I fixed this small issue with the split and join methods on the contact.id so the sidebar NavLink styling is corrected.